### PR TITLE
Update UTC time

### DIFF
--- a/2020-pip/RFP.md
+++ b/2020-pip/RFP.md
@@ -42,7 +42,7 @@ After the RFP period closes we will evaluate the received proposals based on the
 
 Submit your proposal as a [Portable Document Format (PDF)](https://en.wikipedia.org/wiki/PDF) file via email to [Sumana Harihareswara \<sumanah@pypi.org\>](mailto:sumanah@pypi.org), contract project manager working with the Python Software Foundation. Please begin your subject line with "RfP Q1-2020".
 
-Proposals must be submitted before the end of the day **November 22, 2019 [AoE](https://www.timeanddate.com/time/zones/aoe)** (2019-11-22T12:00:00Z).
+Proposals must be submitted before the end of the day **November 22, 2019 [AoE](https://www.timeanddate.com/time/zones/aoe)** (2019-11-23T12:00:00Z).
 
 You can revise an already-submitted proposal by sending a follow-up email before the end of the day November 22nd. Please don't overuse this -- one or two revisions at most, please.
 
@@ -76,7 +76,7 @@ In total, we expect your proposal to be 3-6 pages long, but feel free to go unde
  - Proposal is detailed enough to properly assess further criteria.
  - Formatting and submission requirements:
    - Portable Document Format (PDF)
-   - Emailed to [sumanah@pypi.org](mailto:sumanah@pypi.org) by **November 22, 2019 [AoE](https://www.timeanddate.com/time/zones/aoe)** (2019-11-22T12:00:00Z).
+   - Emailed to [sumanah@pypi.org](mailto:sumanah@pypi.org) by **November 22, 2019 [AoE](https://www.timeanddate.com/time/zones/aoe)** (2019-11-23T12:00:00Z).
 
 ### Experience and competence
 


### PR DESCRIPTION
Is end of day Friday 22 Nov AoE the same as noon Saturday 23 Nov UTC? 

AoE is used on Baker Island:

https://www.timeanddate.com/time/zones/aoe

Frii 22 Nov 23:59 AoE/Baker Island is Sat 23 Nov 11:59 UTC:

https://www.timeanddate.com/worldclock/meetingtime.html?day=22&month=11&year=2019&p1=3399&iv=0

Add a minute to both, and you get end of Friday 22nd Baker Island (midnight) and noon Saturday 23rd UTC. 