### PR TITLE
Update gulpjs URL

### DIFF
--- a/2022-PyPI/RFP.md
+++ b/2022-PyPI/RFP.md
@@ -140,7 +140,7 @@ You can also see the [complete codebase](https://github.com/pypa/warehouse) on G
 Note: Our frontend is primarily static; these tools power the toolchain that creates our final assets.
 
 * [Node](https://nodejs.org/en/)
-* [Gulp](https://gulpjs.org)
+* [Gulp](https://gulpjs.com/)
 * [SASS](https://sass-lang.com)
 * [Stimulus](https://stimulusjs.org/)
 


### PR DESCRIPTION
The link [gulpjs.org](https://gulpjs.org/) does not work. It seems that the actual domain is [gulpjs.com](https://gulpjs.com/), according to [their GitHub page](https://github.com/gulpjs/gulp).